### PR TITLE
Fix comments import; standardizes npm scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "clean": "rimraf './!(rollup.config).js' './*.d.ts'",
     "prebuild": "npm run clean",
     "build": "concurrently \"rollup -c\" \"tsc --emitDeclarationOnly\"",
-    "prepack": "npm run build"
+    "prepare": "npm run build"
   },
   "browser": "./browser.js",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "license": "MIT",
   "private": false,
   "scripts": {
-    "clean": "find -maxdepth 1 \\( -name \"*.js\" -or -name \"*.d.ts\" \\) -type f -not -name rollup.config.js -delete",
+    "clean": "rimraf './!(rollup.config).js' './*.d.ts'",
     "prebuild": "npm run clean",
     "build": "concurrently \"rollup -c\" \"tsc --emitDeclarationOnly\"",
     "prepack": "npm run build"
@@ -34,6 +34,7 @@
     "lodash": "^4.17.11",
     "promise-limit": "^2.7.0",
     "querystring": "^0.2.0",
+    "rimraf": "^2.6.3",
     "rollup": "^1.11.3",
     "rollup-plugin-babel": "^4.3.2",
     "rollup-plugin-commonjs": "^9.3.4",

--- a/src/web-service.ts
+++ b/src/web-service.ts
@@ -24,7 +24,7 @@ type FormPrepare = (data: Form | FormData | undefined | null) => FormData | unde
  * 
  * @example
  * ```typescript
- *import WebService from 'bipbop-webservice/web-service'
+ *import WebService from 'bipbop-webservice/web-service';
  *
  *const maxClients = 10;
  *const fetchOptions: RequestInit = {}; // https://developer.mozilla.org/pt-BR/docs/Web/API/Fetch_API/Using_Fetch

--- a/src/web-service.ts
+++ b/src/web-service.ts
@@ -22,14 +22,18 @@ type FormPrepare = (data: Form | FormData | undefined | null) => FormData | unde
  * se comunicar com a BIPBOP com facilidade usando o esquema fetch
  * https://developer.mozilla.org/pt-BR/docs/Web/API/Fetch_API/Using_Fetch
  * 
- * ```ts
- * import WebService from 'bipbop-webservice'
- * const maxClients: number = 10;
- * const fetchOptions: RequestInit = {}; // https://developer.mozilla.org/pt-BR/docs/Web/API/Fetch_API/Using_Fetch
- * const webService: WebService = new WebService('bipbop-apikey', maxClients, fetchOptions);
- * const response: Response = await webService.request("SELECT FROM 'INFO'.'INFO'");
- * const responseBody: string = await response.text();
- * console.log(responseBody);
+ * @example
+ * ```typescript
+ *import WebService from 'bipbop-webservice/web-service'
+ *
+ *const maxClients = 10;
+ *const fetchOptions: RequestInit = {}; // https://developer.mozilla.org/pt-BR/docs/Web/API/Fetch_API/Using_Fetch
+ *const apiKey = '<secret>'; // Chave de API da BIPBOP (https://www.bipbop.com.br)
+ *
+ *new WebService(apiKey, maxClients, fetchOptions)
+ *  .request("SELECT FROM 'INFO'.'INFO'")
+ *  .then(r => r.text())
+ *  .then(r => console.log(r));
  * ```
  */
 export default class WebService {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2729,7 +2729,7 @@ ret@~0.1.10:
   version "0.1.15"
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
 
-rimraf@2.6.3:
+rimraf@2.6.3, rimraf@^2.6.3:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
   integrity sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==


### PR DESCRIPTION
A importação nos exemplos dos comentários estão incorretas, também, o snippet não é reconhecido como exemplo, provavelmente pela incompatibilidade entre JSDOC e TypeDOC

ref: https://github.com/TypeStrong/typedoc/issues/135#issuecomment-340126097